### PR TITLE
Drop and ignore generated assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage.out
 /dist
 
 /phoenix
+
+/pkg/assets/embed.go


### PR DESCRIPTION
We are embedding the assets as part of our build pipeline, and even
without that the embedded assets are generated by our `make generate`
task anyway, so let's remove thise huge amount of files from the
repository and generate it on build time.

