### PR TITLE
introduce a proxy that resolves apps using the registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/micro/cli v0.2.0
+	github.com/micro/go-micro v1.17.1
 	github.com/ogier/pflag v0.0.1 // indirect
 	github.com/oklog/run v1.0.0
 	github.com/openzipkin/zipkin-go v0.2.2

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -38,6 +38,7 @@ func Server(opts ...Option) (http.Service, error) {
 				options.Logger,
 			),
 		),
+		svc.Registry(service.Service.Options().Registry),
 	)
 
 	{

--- a/pkg/service/v0/option.go
+++ b/pkg/service/v0/option.go
@@ -3,6 +3,7 @@ package svc
 import (
 	"net/http"
 
+	"github.com/micro/go-micro/registry"
 	"github.com/owncloud/ocis-phoenix/pkg/config"
 	"github.com/owncloud/ocis-pkg/log"
 )
@@ -15,6 +16,7 @@ type Options struct {
 	Logger     log.Logger
 	Config     *config.Config
 	Middleware []func(http.Handler) http.Handler
+	Registry   registry.Registry
 }
 
 // newOptions initializes the available default options.
@@ -46,5 +48,12 @@ func Config(val *config.Config) Option {
 func Middleware(val ...func(http.Handler) http.Handler) Option {
 	return func(o *Options) {
 		o.Middleware = val
+	}
+}
+
+// Registry provides a function to set the registry option.
+func Registry(val registry.Registry) Option {
+	return func(o *Options) {
+		o.Registry = val
 	}
 }

--- a/pkg/service/v0/proxy.go
+++ b/pkg/service/v0/proxy.go
@@ -1,0 +1,97 @@
+package svc
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+)
+
+type proxy struct {
+	Default  *httputil.ReverseProxy
+	Director func(r *http.Request)
+}
+
+func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !isWebSocket(r) {
+		// the usual path
+		p.Default.ServeHTTP(w, r)
+		return
+	}
+
+	// the websocket path
+	req := new(http.Request)
+	*req = *r
+	p.Director(req)
+	host := req.URL.Host
+
+	if len(host) == 0 {
+		http.Error(w, "invalid host", 500)
+		return
+	}
+
+	// set x-forward-for
+	if clientIP, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		if ips, ok := req.Header["X-Forwarded-For"]; ok {
+			clientIP = strings.Join(ips, ", ") + ", " + clientIP
+		}
+		req.Header.Set("X-Forwarded-For", clientIP)
+	}
+
+	// connect to the backend host
+	conn, err := net.Dial("tcp", host)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+	// hijack the connection
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "failed to connect", 500)
+		return
+	}
+
+	nc, _, err := hj.Hijack()
+	if err != nil {
+		return
+	}
+
+	defer nc.Close()
+	defer conn.Close()
+
+	if err = req.Write(conn); err != nil {
+		return
+	}
+
+	errCh := make(chan error, 2)
+
+	cp := func(dst io.Writer, src io.Reader) {
+		_, err := io.Copy(dst, src)
+		errCh <- err
+	}
+
+	go cp(conn, nc)
+	go cp(nc, conn)
+
+	<-errCh
+}
+
+func isWebSocket(r *http.Request) bool {
+	contains := func(key, val string) bool {
+		vv := strings.Split(r.Header.Get(key), ",")
+		for _, v := range vv {
+			if val == strings.ToLower(strings.TrimSpace(v)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if contains("Connection", "upgrade") && contains("Upgrade", "websocket") {
+		return true
+	}
+
+	return false
+}

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -3,19 +3,63 @@ package svc
 import (
 	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"os"
+	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-chi/chi"
+	"github.com/micro/go-micro/client/selector"
+	"github.com/micro/go-micro/config/cmd"
+	"github.com/micro/go-micro/registry"
+	"github.com/micro/go-micro/registry/cache"
 	"github.com/owncloud/ocis-phoenix/pkg/assets"
 	"github.com/owncloud/ocis-phoenix/pkg/config"
 	"github.com/owncloud/ocis-pkg/log"
 )
 
 var (
+	re = regexp.MustCompile("^[a-zA-Z0-9]+([a-zA-Z0-9-]*[a-zA-Z0-9]*)?$")
 	// ErrConfigInvalid is returned when the config parse is invalid.
 	ErrConfigInvalid = `Invalid or missing config`
 )
+
+type reg struct {
+	registry.Registry
+
+	sync.Mutex
+	lastPull time.Time
+	services []*registry.Service
+}
+
+func (r *reg) watch() {
+Loop:
+	for {
+		// get a watcher
+		w, err := r.Registry.Watch()
+		if err != nil {
+			time.Sleep(time.Second)
+			continue
+		}
+
+		// loop results
+		for {
+			_, err := w.Next()
+			if err != nil {
+				w.Stop()
+				time.Sleep(time.Second)
+				goto Loop
+			}
+
+			// next pull will be from the registry
+			r.Lock()
+			r.lastPull = time.Time{}
+			r.Unlock()
+		}
+	}
+}
 
 // Service defines the extension handlers.
 type Service interface {
@@ -30,14 +74,28 @@ func NewService(opts ...Option) Service {
 	m := chi.NewMux()
 	m.Use(options.Middleware...)
 
+	// use the caching registry
+	cache := cache.New((*cmd.DefaultOptions().Registry))
+	reg := &reg{Registry: cache}
+
+	// start the watcher
+	go reg.watch()
+
 	svc := Phoenix{
-		logger: options.Logger,
-		config: options.Config,
-		mux:    m,
+		logger:   options.Logger,
+		config:   options.Config,
+		mux:      m,
+		registry: reg,
 	}
 
 	m.Route(options.Config.HTTP.Root, func(r chi.Router) {
 		r.Get("/config.json", svc.Config)
+		r.Mount("/apps/draw-io", svc.Static())
+		r.Mount("/apps/files", svc.Static())
+		r.Mount("/apps/markdown-editor", svc.Static())
+		r.Mount("/apps/media-viewer", svc.Static())
+		r.Mount("/apps/pdf-viewer", svc.Static())
+		r.Mount("/apps/{service:[a-zA-Z0-9]+}", svc.Proxy())
 		r.Mount("/", svc.Static())
 	})
 
@@ -46,9 +104,10 @@ func NewService(opts ...Option) Service {
 
 // Phoenix defines implements the business logic for Service.
 type Phoenix struct {
-	logger log.Logger
-	config *config.Config
-	mux    *chi.Mux
+	logger   log.Logger
+	config   *config.Config
+	mux      *chi.Mux
+	registry registry.Registry
 }
 
 // ServeHTTP implements the Service interface.
@@ -126,4 +185,54 @@ func (p Phoenix) Static() http.HandlerFunc {
 
 		static.ServeHTTP(w, r)
 	})
+}
+
+// Proxy forwards requests to services using the registry
+func (p Phoenix) Proxy() http.Handler {
+
+	sel := selector.NewSelector(
+		selector.Registry(p.registry),
+	)
+
+	director := func(r *http.Request) {
+		kill := func() {
+			r.URL.Host = ""
+			r.URL.Path = ""
+			r.URL.Scheme = ""
+			r.Host = ""
+			r.RequestURI = ""
+		}
+
+		parts := strings.Split(r.URL.Path, "/")
+		if len(parts) < 2 {
+			kill()
+			return
+		}
+		if !re.MatchString(parts[1]) {
+			kill()
+			return
+		}
+		next, err := sel.Select(p.config.Phoenix.Namespace + "." + parts[2]) // 1 is "apps"
+		if err != nil {
+			kill()
+			return
+		}
+
+		s, err := next()
+		if err != nil {
+			kill()
+			return
+		}
+
+		r.Header.Set( /*BasePathHeader*/ "X-Micro-Web-Base-Path", "/"+parts[2])
+		r.URL.Host = s.Address
+		r.URL.Path = "/" + strings.Join(parts[3:], "/")
+		r.URL.Scheme = "http"
+		r.Host = r.URL.Host
+	}
+
+	return &proxy{
+		Default:  &httputil.ReverseProxy{Director: director},
+		Director: director,
+	}
 }


### PR DESCRIPTION
introduces a proxy that will forward requests to /apps/<appname> to the corresponding service.
files, draw-io, markdown-editor, media-viewer and pdf-viewer will be served from the build in assets
anything else, eg. `hello` will be resolved by querying the registry for `namespace+appname`, which for the default namespace `com.owncloud.web` will be `com.owncloud.web.hello`