### PR TITLE
Fix external_apps config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,7 +65,7 @@ type OIDC struct {
 //	  }
 //  }
 type ExternalApp struct {
-	Name string `json:"name,omitempty"`
+	ID   string `json:"id,omitempty"`
 	Path string `json:"path,omitempty"`
 	// Config is completely dynamic, because it depends on the extension
 	Config map[string]interface{} `json:"config,omitempty"`


### PR DESCRIPTION
config setting is based on comparing the app `id` ... something like a `name` does not exist