### PR TITLE
Avoid flags parsing

### DIFF
--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -138,8 +138,6 @@ func Server(cfg *config.Config) cli.Command {
 					http.Namespace(cfg.HTTP.Namespace),
 					http.Config(cfg),
 					http.Metrics(metrics),
-					http.Flags(flagset.RootWithConfig(cfg)),
-					http.Flags(flagset.ServerWithConfig(cfg)),
 				)
 
 				if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,13 +38,12 @@ type Asset struct {
 
 // PhoenixConfig defines the available phoenix configuration for a dynamically rendered config.json.
 type PhoenixConfig struct {
-	Server        string `json:"server,omitempty"`
-	Theme         string `json:"theme,omitempty"`
-	Version       string `json:"version,omitempty"` // TODO what is version used for?
-	OpenIDConnect OIDC   `json:"openIdConnect,omitempty"`
-	// TODO add nilasempty when https://go-review.googlesource.com/c/go/+/205897/ is released
-	Apps         []string      `json:"apps"`
-	ExternalApps []ExternalApp `json:"external_apps,omitempty"`
+	Server        string        `json:"server,omitempty"`
+	Theme         string        `json:"theme,omitempty"`
+	Version       string        `json:"version,omitempty"`
+	OpenIDConnect OIDC          `json:"openIdConnect,omitempty"`
+	Apps          []string      `json:"apps,omitempty"`
+	ExternalApps  []ExternalApp `json:"external_apps,omitempty"`
 }
 
 // OIDC defines the available oidc configuration
@@ -57,17 +56,9 @@ type OIDC struct {
 }
 
 // ExternalApp defines an external phoenix app.
-// {
-//	"name": "hello",
-//	"path": "http://localhost:9105/hello.js",
-//	  "config": {
-//	    "url": "http://localhost:9105"
-//	  }
-//  }
 type ExternalApp struct {
-	ID   string `json:"id,omitempty"`
-	Path string `json:"path,omitempty"`
-	// Config is completely dynamic, because it depends on the extension
+	ID     string                 `json:"id,omitempty"`
+	Path   string                 `json:"path,omitempty"`
 	Config map[string]interface{} `json:"config,omitempty"`
 }
 


### PR DESCRIPTION
Flags should be provided on `cli.Command.Flags` and not re-evaluated and passed down the tree.

@butonic this behavior changes some parameters you're setting on `ocis`, to be more precise, [this values](https://github.com/owncloud/ocis/blob/master/pkg/command/phoenix_ocis.go#L15-L16).

I'll update them if this PR behaves as it is intended.