### PR TITLE
fix: remove flagset options

### DIFF
--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -143,8 +143,6 @@ func Server(cfg *config.Config) cli.Command {
 					http.Namespace(cfg.HTTP.Namespace),
 					http.Config(cfg),
 					http.Metrics(metrics),
-					http.Flags(flagset.RootWithConfig(cfg)),
-					http.Flags(flagset.ServerWithConfig(cfg)),
 				)
 
 				if err != nil {


### PR DESCRIPTION
Flagsets are not necessary for initializing the web server/service.
Passing them will cause micro to call the flagset function again which
then overrides the given value with the default value.

Fixes #33

