### PR TITLE
add silent refresh middleware

### DIFF
--- a/changelog/unreleased/add-silentrefresh-middleware
+++ b/changelog/unreleased/add-silentrefresh-middleware
@@ -1,0 +1,6 @@
+Bugfix: allow silent refresh of access token
+
+Sets the `X-Frame-Options Header` to `SAMEORIGIN` so the oidc client can refresh the token in an iframe.
+
+https://github.com/owncloud/ocis-konnectd/issues/69
+https://github.com/owncloud/ocis-phoenix/pull/69

--- a/changelog/unreleased/add-silentrefresh-middleware
+++ b/changelog/unreleased/add-silentrefresh-middleware
@@ -1,6 +1,6 @@
 Bugfix: allow silent refresh of access token
 
-Sets the `X-Frame-Options Header` to `SAMEORIGIN` so the oidc client can refresh the token in an iframe.
+Sets the `X-Frame-Options` header to `SAMEORIGIN` so the oidc client can refresh the token in an iframe.
 
 https://github.com/owncloud/ocis-konnectd/issues/69
 https://github.com/owncloud/ocis-phoenix/pull/69

--- a/pkg/middleware/silentrefresh.go
+++ b/pkg/middleware/silentrefresh.go
@@ -1,0 +1,13 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+// SilentRefresh allows the oidc client lib to silently refresh the token in an iframe
+func SilentRefresh(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	phoenixmid "github.com/owncloud/ocis-phoenix/pkg/middleware"
 	svc "github.com/owncloud/ocis-phoenix/pkg/service/v0"
 	"github.com/owncloud/ocis-phoenix/pkg/version"
 	"github.com/owncloud/ocis-pkg/v2/middleware"
@@ -30,6 +31,7 @@ func Server(opts ...Option) (http.Service, error) {
 			middleware.Cache,
 			middleware.Cors,
 			middleware.Secure,
+			phoenixmid.SilentRefresh,
 			middleware.Version(
 				"phoenix",
 				version.String,


### PR DESCRIPTION
Sets the `X-Frame-Options` Header to `SAMEORIGIN` so the oidc client can refresh the token in an iframe.

part of https://github.com/owncloud/ocis-konnectd/issues/69

I also tried only setting the  `X-Frame-Options` header for `oidc-silent-redirect.html` and then the `index.html` it was still not working so I am now setting it for all requests to the phoenix server. 