### PR TITLE
Default hide searchbar

### DIFF
--- a/changelog/unreleased/hide-searchbar.md
+++ b/changelog/unreleased/hide-searchbar.md
@@ -1,0 +1,6 @@
+Change: hide searchbar by default
+
+Since file search is not working at the moment we decided to hide the search bar by default.
+
+https://github.com/owncloud/product/issues/116
+https://github.com/owncloud/ocis-phoenix/pull/74

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,13 +38,13 @@ type Asset struct {
 
 // PhoenixConfig defines the available phoenix configuration for a dynamically rendered config.json.
 type PhoenixConfig struct {
-	Server        string `json:"server,omitempty"`
-	Theme         string `json:"theme,omitempty"`
-	Version       string `json:"version,omitempty"` // TODO what is version used for?
-	OpenIDConnect OIDC   `json:"openIdConnect,omitempty"`
-	// TODO add nilasempty when https://go-review.googlesource.com/c/go/+/205897/ is released
-	Apps         []string      `json:"apps"`
-	ExternalApps []ExternalApp `json:"external_apps,omitempty"`
+	Server        string                 `json:"server,omitempty"`
+	Theme         string                 `json:"theme,omitempty"`
+	Version       string                 `json:"version,omitempty"` // TODO what is version used for?
+	OpenIDConnect OIDC                   `json:"openIdConnect,omitempty"`
+	Apps          []string               `json:"apps"` // TODO add nilasempty when https://go-review.googlesource.com/c/go/+/205897/ is released
+	ExternalApps  []ExternalApp          `json:"external_apps,omitempty"`
+	Options       map[string]interface{} `json:"options,omitempty"`
 }
 
 // OIDC defines the available oidc configuration

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -64,7 +64,7 @@ func (p Phoenix) getPayload() (payload []byte, err error) {
 
 		// provide default ocis-web options
 		if p.config.Phoenix.Config.Options == nil {
-			p.config.Phoenix.Config.Options = make(map[string]interface{}, 0)
+			p.config.Phoenix.Config.Options = make(map[string]interface{})
 			p.config.Phoenix.Config.Options["hideSearchBar"] = true
 		}
 

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -62,6 +62,12 @@ func (p Phoenix) getPayload() (payload []byte, err error) {
 	if p.config.Phoenix.Path == "" {
 		// render dynamically using config
 
+		// provide default ocis-web options
+		if p.config.Phoenix.Config.Options == nil {
+			p.config.Phoenix.Config.Options = make(map[string]interface{}, 0)
+			p.config.Phoenix.Config.Options["hideSearchBar"] = true
+		}
+
 		// make apps render as empty array if it is empty
 		// TODO remove once https://github.com/golang/go/issues/27589 is fixed
 		if len(p.config.Phoenix.Config.Apps) == 0 {


### PR DESCRIPTION
Includes the option to hide the searchbar in phoenix when ocis-proxy runs with the builtin phoenix configuration.

Please note that the phoenix PR that uses the option is merged in phoenix master, but not included in ocis-phoenix, yet.