### PR TITLE
Die on missing assets

### DIFF
--- a/changelog/unreleased/exit-on-unresolved-assets.md
+++ b/changelog/unreleased/exit-on-unresolved-assets.md
@@ -1,0 +1,7 @@
+Bugfix: exit when assets are not found
+
+When a non-existing assets folders is specified, there was only a warning log statement and the service served
+the builtin assets instead. It is safe to exit the service in such a scenario, instead of serving other assets
+than specified. We changed the log level to `Fatal` on non-existing assets.
+
+https://github.com/owncloud/ocis-phoenix/pull/76

--- a/pkg/assets/assets.go
+++ b/pkg/assets/assets.go
@@ -36,9 +36,9 @@ func (a assets) Open(original string) (http.File, error) {
 				return f, nil
 			}
 		} else {
-			a.logger.Warn().
+			a.logger.Fatal().
 				Str("path", a.config.Asset.Path).
-				Msg("Assets directory doesn't exist")
+				Msg("assets directory doesn't exist")
 		}
 	}
 


### PR DESCRIPTION
With this PR, when `PHOENIX_ASSET_PATH` was specified but the assets can't be found, ocis-phoenix will exit now instead of serving the builtin assets as fallback. Achieved this by changing the log level to `Fatal`, since it logs the error and does an exit(1) afterwards.