### PR TITLE
Die on invalid config

### DIFF
--- a/changelog/unreleased/exit-on-unresolved-assets.md
+++ b/changelog/unreleased/exit-on-unresolved-assets.md
@@ -1,7 +1,10 @@
-Bugfix: exit when assets are not found
+Bugfix: exit when assets or config are not found
 
-When a non-existing assets folders is specified, there was only a warning log statement and the service served
+When a non-existing assets folder is specified, there was only a warning log statement and the service served
 the builtin assets instead. It is safe to exit the service in such a scenario, instead of serving other assets
 than specified. We changed the log level to `Fatal` on non-existing assets.
+Similar for the web config, it was not failing on service level, but only showing an error in the web ui, wenn
+the specified config file could not be found. We changed the log level to `Fatal` as well.
 
 https://github.com/owncloud/ocis-phoenix/pull/76
+https://github.com/owncloud/ocis-phoenix/pull/77

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -79,21 +79,19 @@ func (p Phoenix) getPayload() (payload []byte, err error) {
 
 	// try loading from file
 	if _, err = os.Stat(p.config.Phoenix.Path); os.IsNotExist(err) {
-		p.logger.Error().
+		p.logger.Fatal().
 			Err(err).
 			Str("config", p.config.Phoenix.Path).
-			Msg("Phoenix config doesn't exist")
-		return
+			Msg("phoenix config doesn't exist")
 	}
 
 	payload, err = ioutil.ReadFile(p.config.Phoenix.Path)
 
 	if err != nil {
-		p.logger.Error().
+		p.logger.Fatal().
 			Err(err).
 			Str("config", p.config.Phoenix.Path).
-			Msg("Failed to read custom config")
-
+			Msg("failed to read custom config")
 	}
 	return
 }


### PR DESCRIPTION
Similar to https://github.com/owncloud/ocis-phoenix/pull/76, we now also let the service die when the config file doesn't exist. 