### PR TITLE
Fix external app urls

### DIFF
--- a/changelog/unreleased/fix-external-app-urls
+++ b/changelog/unreleased/fix-external-app-urls
@@ -1,0 +1,6 @@
+Bugfix: Fix external app URLs
+
+The URLs for the default set of external apps was hardcoded to localhost:9200. We fixed that by using the server url from the already existing config variable.
+
+https://github.com/owncloud/product/issues/218
+https://github.com/owncloud/ocis-phoenix/pull/83

--- a/changelog/unreleased/fix-external-app-urls
+++ b/changelog/unreleased/fix-external-app-urls
@@ -1,6 +1,6 @@
 Bugfix: Fix external app URLs
 
-The URLs for the default set of external apps was hardcoded to localhost:9200. We fixed that by using the server url from the already existing config variable.
+The URLs for the default set of external apps was hardcoded to localhost:9200. We fixed that by using relative paths instead.
 
 https://github.com/owncloud/product/issues/218
 https://github.com/owncloud/ocis-phoenix/pull/83

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -72,11 +72,11 @@ func (p Phoenix) getPayload() (payload []byte, err error) {
 			p.config.Phoenix.Config.ExternalApps = []config.ExternalApp{
 				{
 					ID:   "accounts",
-					Path: singleJoiningSlash(p.config.Phoenix.Config.Server, "accounts.js"),
+					Path: "/accounts.js",
 				},
 				{
 					ID:   "settings",
-					Path: singleJoiningSlash(p.config.Phoenix.Config.Server, "settings.js"),
+					Path: "/settings.js",
 				},
 			}
 		}
@@ -107,18 +107,6 @@ func (p Phoenix) getPayload() (payload []byte, err error) {
 			Msg("failed to read custom config")
 	}
 	return
-}
-
-func singleJoiningSlash(a, b string) string {
-	aslash := strings.HasSuffix(a, "/")
-	bslash := strings.HasPrefix(b, "/")
-	switch {
-	case aslash && bslash:
-		return a + b[1:]
-	case !aslash && !bslash:
-		return a + "/" + b
-	}
-	return a + b
 }
 
 // Config implements the Service interface.

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -72,11 +72,11 @@ func (p Phoenix) getPayload() (payload []byte, err error) {
 			p.config.Phoenix.Config.ExternalApps = []config.ExternalApp{
 				{
 					ID:   "accounts",
-					Path: "https://localhost:9200/accounts.js",
+					Path: singleJoiningSlash(p.config.Phoenix.Config.Server, "accounts.js"),
 				},
 				{
 					ID:   "settings",
-					Path: "https://localhost:9200/settings.js",
+					Path: singleJoiningSlash(p.config.Phoenix.Config.Server, "settings.js"),
 				},
 			}
 		}
@@ -107,6 +107,18 @@ func (p Phoenix) getPayload() (payload []byte, err error) {
 			Msg("failed to read custom config")
 	}
 	return
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
 }
 
 // Config implements the Service interface.


### PR DESCRIPTION
The URLs for the default set of external apps was hardcoded to localhost:9200. We fixed that by using the server url from the already existing config variable.

Fixes https://github.com/owncloud/product/issues/218